### PR TITLE
Fixes yaml by adding missing colon in final example

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ testgpt -i ./src/component.tsx -c `./testgpt.config.yaml`
 The file `testgpt.config.yaml` supports the `examples` property for each file extension:
 
 ```yaml
-.tsx
+.tsx:
    techs:
       - jest
       - react-testing-library


### PR DESCRIPTION
Fixes this yaml parsing error:

```
YAMLParseError: Implicit keys need to be on a single line at line 1, column 1:
```

PS.  Thanks for this project.  Giving it a first test today.