### PR TITLE
Add --systemMessage option

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -22,6 +22,7 @@ export const parseCommand = () => {
     .option("-k, --apiKey <char>")
     .option("-m, --model <char>")
     .option("-p, --promptTemplate <char>")
+    .option("-y, --systemMessage <char>")
     .option("-t, --techs <char>")
     .option("-n, --instructions <char>")
     .option("-c, --config <char>")
@@ -117,6 +118,7 @@ export const executeForFile = async ({
   outputFile,
   apiKey,
   model,
+  systemMessage,
   promptTemplate,
   techs,
   instructions,
@@ -183,6 +185,7 @@ export const executeForFile = async ({
     outputFile,
     apiKey,
     model: model as IModel,
+    systemMessage,
     promptTemplate,
     examples,
     techs: parsedTechs,

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export interface ICommandArgs {
   outputFile?: string;
   apiKey: string;
   model: string;
+  systemMessage: string;
   promptTemplate: string;
   techs: string;
   instructions: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -147,16 +147,19 @@ export type ICompletionRequest = CreateChatCompletionRequest;
 
 export const getCompletionRequest = (
   model: IModel,
+  systemMessage: string,
   prompt: string,
   examples: IMessage[]
 ) => {
+  systemMessage ??=
+    "You are my unit testing assistant, you will help me write unit tests for the files I provide, your reply will only include the unit tests without any additional information, starting your response with ``` and ending it with ``` directly will help me understand your response better.";
+
   return {
     model,
     messages: [
       {
         role: ERole.System,
-        content:
-          "You are an assistant that provides unit tests for a given file.",
+        content: systemMessage,
       },
       ...examples,
       {
@@ -221,6 +224,7 @@ interface IAutoTestArgs {
   outputFile: string;
   apiKey: string;
   model: IModel;
+  systemMessage?: string;
   promptTemplate?: string;
   modelEndpoint?: string;
   examples?: IExample[];
@@ -234,6 +238,7 @@ export const autoTest = async ({
   outputFile,
   apiKey,
   model,
+  systemMessage,
   promptTemplate,
   examples,
   techs,
@@ -284,6 +289,7 @@ export const autoTest = async ({
 
   const completionRequest = getCompletionRequest(
     model,
+    systemMessage,
     prompt,
     exampleMessages
   );


### PR DESCRIPTION
The -y/--systemMessage option could be optionally given for a custom system message, which will be sent to the OpenAI Completion requests to indicate base guidelines and characteristics.